### PR TITLE
passes primitive types by value, odes [cxx]

### DIFF
--- a/odes/cxx/impulse.cpp
+++ b/odes/cxx/impulse.cpp
@@ -66,22 +66,22 @@ using ode::iEuler ;
 using ode::RK2 ;
 
 // lambda, odefun, RHS of the ODE f(t, y)
-std::function < double(const double&, const double&) >
-odefun = [](const double& t, const double& y) -> double {
+std::function < double(double, double) >
+odefun = [](double t, double y) -> double {
 	const double k = RATE ;
 	const double b = FEXT ;
 	return (b - k * y) ;
 } ;
 
 // analytic expression for the step-response, y(t)
-auto fstep = [](const double& t) -> double {
+auto fstep = [](double t) -> double {
 	const double k  = RATE ;
 	const double b  = FEXT ;
 	return ( -(b / k) * exp(-k * t) + b / k ) ;
 } ;
 
 // analytic expression for the impulse-response, y(t)
-auto fimpulse = [](const double& t) -> double {
+auto fimpulse = [](double t) -> double {
 	const double k  = RATE ;
 	const double b  = FEXT ;
 	return  ( b * exp(-k * t) );

--- a/odes/cxx/isothermal-second-order-kinetics-batch-reactor.cpp
+++ b/odes/cxx/isothermal-second-order-kinetics-batch-reactor.cpp
@@ -74,14 +74,14 @@ using ode::iEuler ;
 using ode::RK2 ;
 
 // lambda, odefun, RHS of the ODE f(t, y)
-std::function < double(const double&, const double&) >
-odefun = [](const double& t, const double& y) -> double {
+std::function < double(double, double) >
+odefun = [](double t, double y) -> double {
 	const double beta = BETA ;
 	return (-beta * y * y);
 } ;
 
 // analytic expression for the non-dimensional reactant concentration, y(t)
-auto fsol = [](const double& t) -> double {
+auto fsol = [](double t) -> double {
 	return ( 1.0 / (1.0 + BETA * t) );
 } ;
 

--- a/odes/cxx/module-fzero-solver.cpp
+++ b/odes/cxx/module-fzero-solver.cpp
@@ -60,27 +60,26 @@ export namespace nlsolver {
 		bool verbose ;
 	} ;
 
-	double fzero(double,double,std::function<double(const double&)>&,
-		     config ) ;
+	double fzero(double, double, std::function<double(double)>&,
+		     config);
 }
 
 
 // declarations (prototypes)
-void report (const int& n, const std::string& nm,
-             const nlsolver::config& opt) ;
+void report (int n, std::string nm, const nlsolver::config& opt) ;
 void check_bounds ( double& lb, double& ub ) ;
 
-void check_bracket ( const double&, const double&, const std::string&,
-	       	     std::function<double(const double&)>& ) ;
+void check_bracket ( double, double, std::string,
+		     std::function<double(double)>& ) ;
 
 double shift ( double&, double&, double&, 
-	       std::function<double(const double&)>& ) ;
+	       std::function<double(double)>& ) ;
 
 
 
 // implementations
 double nlsolver::fzero   ( double lb, double ub, 
-		           std::function<double(const double&)>& f,
+		           std::function<double(double)>& f,
 	       	           config opt = config() )
 {	// Shifter Method
 
@@ -109,9 +108,8 @@ void check_bounds ( double& lb, double& ub ) {
 }
 
 
-void check_bracket ( const double& lb, const double& ub, 
-		     const std::string& nm, 
-		     std::function<double(const double&)>& f )
+void check_bracket ( double lb, double ub, std::string nm,
+		     std::function<double(double)>& f )
 {
 	// complains if there's no root in given interval
 	if ( f(lb) * f(ub) > 0. ) {
@@ -124,8 +122,7 @@ void check_bracket ( const double& lb, const double& ub,
 }
 
 
-void report (const int& n, const std::string& nm,
-             const nlsolver::config& opt)
+void report (int n, std::string nm, const nlsolver::config& opt)
 {
 	// reports if the method has been successful
 	if (n != opt.max_iter) {
@@ -143,7 +140,7 @@ void report (const int& n, const std::string& nm,
 
 
 double shift ( double& lb, double& ub, double& xn,
-	       std::function<double(const double&)>& f )
+	       std::function<double(double)>& f )
 {	// like bisector but uses the step (presumably) closer to the root
 	double fn ;
 	double xb = 0.5 * (lb + ub) ;

--- a/odes/cxx/module-ode-solvers.cpp
+++ b/odes/cxx/module-ode-solvers.cpp
@@ -43,33 +43,33 @@ export namespace ode {
 	// Euler's Method
 	std::tuple< std::vector<double>, std::vector<double> >&
 	Euler ( std::tuple< std::vector<double>, std::vector<double> >&,
-		const double&, const double&, const double&, const int&,
-		std::function< double(const double&, const double&) >& ) ;
+		double, double, double, int,
+		std::function< double(double, double) >& ) ;
 
 	// implicit Euler's method
 	std::tuple< std::vector<double>, std::vector<double> >&
 	iEuler ( std::tuple< std::vector<double>, std::vector<double> >&,
-		 const double&, const double&, const double&, const int&,
-		 std::function< double(const double&, const double&) >& ) ;
+		 double, double, double, int,
+		 std::function< double(double, double) >& ) ;
 	
 	// second-order Runge-Kutta Method
 	std::tuple< std::vector<double>, std::vector<double> >&
 	RK2 ( std::tuple< std::vector<double>, std::vector<double> >&,
-	      const double&, const double&, const double&, const int&,
-	      std::function< double(const double&, const double&) >& ) ;
+	      double, double, double, int,
+	      std::function< double(double, double) >& ) ;
 
 }
 
 // declarations
-std::vector<double>& linspace ( std::vector<double>&, const double&,
-		                const double&, const int& ) ;
+std::vector<double>& linspace ( std::vector<double>&, double,
+		                double, int ) ;
 
 // implementations
 std::tuple< std::vector<double>, std::vector<double> >&
 ode::Euler (std::tuple< std::vector<double>, std::vector<double> >& odesol,
-	    const double& ti, const double& tf, const double& yi,
-	    const int& N,
-	    std::function< double(const double&, const double&) >& f )
+	    double ti, double tf, double yi,
+	    int N,
+	    std::function< double(double, double) >& f )
 {	// possible implementation of Euler's explicit method
 
 	double dt = (tf - ti) / ( (double) N );		// time-step, dt
@@ -92,9 +92,9 @@ ode::Euler (std::tuple< std::vector<double>, std::vector<double> >& odesol,
 
 std::tuple< std::vector<double>, std::vector<double> >&
 ode::iEuler(std::tuple< std::vector<double>, std::vector<double> >& odesol,
-	    const double& ti, const double& tf, const double& yi,
-	    const int& N,
-	    std::function< double(const double&, const double&) >& f )
+	    double ti, double tf, double yi,
+	    int N,
+	    std::function< double(double, double) >& f )
 {	// possible implementation of Euler's implicit method
 
 	double K1, K2 ;					// slopes
@@ -105,7 +105,7 @@ ode::iEuler(std::tuple< std::vector<double>, std::vector<double> >& odesol,
 	typedef std::vector<double>::size_type size ;	// typedef
 	size i ;					// counter
 
-	std::function<double(const double&)> objf = [&](const double& yn) {
+	std::function<double(double)> objf = [&](double yn) {
 		// objective function supplied to nonlinear solver fzero
 		return (yn - y[i] - dt * f(t[i+1], yn));
 	};
@@ -131,9 +131,9 @@ ode::iEuler(std::tuple< std::vector<double>, std::vector<double> >& odesol,
 
 std::tuple< std::vector<double>, std::vector<double> >&
 ode::RK2 ( std::tuple< std::vector<double>, std::vector<double> >& odesol,
-	   const double& ti, const double& tf, const double& yi,
-	   const int& N,
-	   std::function< double(const double&, const double&) >& f )
+	   double ti, double tf, double yi,
+	   int N,
+	   std::function< double(double, double) >& f )
 {	// implements an Euler-based, second-order, Runge-Kutta Method
 
 	double K1, K2 ;					// slopes
@@ -157,8 +157,8 @@ ode::RK2 ( std::tuple< std::vector<double>, std::vector<double> >& odesol,
 }
 
 
-std::vector<double>& linspace (std::vector<double>& t, const double& start,
-		               const double& end, const int& numel)
+std::vector<double>& linspace (std::vector<double>& t, double start,
+		               double end, int numel)
 {	// implements a numpy-like linspace method
 
 

--- a/odes/cxx/module-ode-solvers.cpp
+++ b/odes/cxx/module-ode-solvers.cpp
@@ -157,16 +157,26 @@ ode::RK2 ( std::tuple< std::vector<double>, std::vector<double> >& odesol,
 }
 
 
-std::vector<double>& linspace (std::vector<double>& t, const double& ti,
-		               const double& tf, const int& numel)
+std::vector<double>& linspace (std::vector<double>& t, const double& start,
+		               const double& end, const int& numel)
 {	// implements a numpy-like linspace method
+
+
 	t.clear();				// clears (existing) data
 	t.reserve (numel);			// prellocates for speed
-	std::vector<int> idx (numel);		// index vector [0, numel)
-	std::iota (idx.begin(), idx.end(), 0);
-	double dt = (tf - ti) / ( (double) (numel - 1) );
-	auto f = [&](const int& i) { return (ti + ( (double) i) * dt); };
-	std::transform (idx.begin(), idx.end(), std::back_inserter(t), f);
+
+
+	// computes the time-step
+	double dt = (end - start) / ( (double) (numel - 1) );
+
+
+	// pushes the ith time t[i] unto the back of the time vector
+	for (int i = 0; i != numel; ++i)
+	{
+		double ti = (start + ( (double) i ) * dt);
+		t.push_back(ti);
+	}
+
 	return t ;
 }
 

--- a/odes/cxx/ramp.cpp
+++ b/odes/cxx/ramp.cpp
@@ -66,15 +66,15 @@ using ode::iEuler ;
 using ode::RK2 ;
 
 // lambda, odefun, RHS of the ODE f(t, y)
-std::function < double(const double&, const double&) >
-odefun = [](const double& t, const double& y) -> double {
+std::function < double(double, double) >
+odefun = [](double t, double y) -> double {
 	const double k = RATE ;
 	const double b = FEXT ;
 	return (b * t - k * y) ;
 } ;
 
 // analytic expression for the ramp-response, y(t)
-auto framp = [](const double& t) -> double {
+auto framp = [](double t) -> double {
 	const double k  = RATE ;
 	const double b  = FEXT ;
 	return (b / (k * k) * (exp(-k * t) - 1.0) + b / k * t);

--- a/odes/cxx/sinusoid.cpp
+++ b/odes/cxx/sinusoid.cpp
@@ -67,8 +67,8 @@ using ode::iEuler ;
 using ode::RK2 ;
 
 // lambda, odefun, RHS of the ODE f(t, y)
-std::function < double(const double&, const double&) >
-odefun = [](const double& t, const double& y) -> double {
+std::function < double(double, double) >
+odefun = [](double t, double y) -> double {
 	const double k = RATE ;
 	const double b = FEXT ;
 	const double w = OMEGA ;
@@ -76,7 +76,7 @@ odefun = [](const double& t, const double& y) -> double {
 } ;
 
 // analytic expression for the sinusoid-response, y(t)
-auto fsinusoid = [](const double& t) -> double {
+auto fsinusoid = [](double t) -> double {
 	const double k  = RATE ;
 	const double b  = FEXT ;
 	const double w  = OMEGA ;

--- a/odes/cxx/test.cpp
+++ b/odes/cxx/test.cpp
@@ -69,8 +69,8 @@ int main() {
 	tuple < vector<double>, vector<double> > odesol_RK2 ;
 
 	// lambda, odefun, RHS of the ODE f(t, y)
-	std::function < double(const double&, const double&) >
-	f = [](const double& t, const double& y) -> double {
+	std::function < double(double, double) >
+	f = [](double t, double y) -> double {
 		const double k = 1.0 ;
 		return (-k * y) ;
        	} ;


### PR DESCRIPTION
In this revision the internal linspace method used by the methods defined in the ODE module has been simplified.