### PR TITLE
fixes iteration count, nonlinear solvers

### DIFF
--- a/nonlinear-equation-solvers/clang/nlsolvers.c
+++ b/nonlinear-equation-solvers/clang/nlsolvers.c
@@ -122,7 +122,7 @@ double shifter_base ( double lb, double ub, double f(double),
 
 void report (int max_iter, int n, char nm[], bool verbose) {
 	// reports if the method has been successful
-	if (n < max_iter) {
+	if (n != max_iter) {
 		if (verbose) {
 			printf("%s Method:\n", nm) ;
 			printf("solution found in %d iterations\n", n) ;

--- a/nonlinear-equation-solvers/cxx/module-nonlinear-solvers.cpp
+++ b/nonlinear-equation-solvers/cxx/module-nonlinear-solvers.cpp
@@ -167,7 +167,7 @@ void report (const int& n, const std::string& nm,
              const nlsolver::config& opt)
 {
 	// reports if the method has been successful
-	if (n < opt.max_iter) {
+	if (n != opt.max_iter) {
 		if (opt.verbose) {
 			std::cout << nm << " Method:" << std::endl ;
 			std::cout << "solution found in " << n << " "

--- a/nonlinear-equation-solvers/fortran/nlsolvers.for
+++ b/nonlinear-equation-solvers/fortran/nlsolvers.for
@@ -70,7 +70,7 @@ module nlsolvers
             call bounds_check  (lb, ub, a, b)
             call optset(conf, opts)
 
-            n = 0
+            n = 1
             x = 0.5_real64 * (a + b)
             do while (n /= conf % max_iter .and. abs( fp(x) ) > conf % tol)
                 call bisector (a, b, x, fp)
@@ -118,7 +118,7 @@ module nlsolvers
             call bounds_check  (lb, ub, a, b)
             call optset(conf, opts)
 
-            n = 0
+            n = 1
             x = ( a * fp(b) - b * fp(a) ) / ( fp(b) - fp(a) )
             do while (n /= conf % max_iter .and. abs( fp(x) ) > conf % tol)
                 call interp (a, b, x, fp)
@@ -163,7 +163,7 @@ module nlsolvers
             call bounds_check  (lb, ub, a, b)
             call optset(conf, opts)
 
-            n = 0
+            n = 1
             x1 = 0.5_real64 * (a + b)
             x2 = ( a * fp(b) - b * fp(a) ) / ( fp(b) - fp(a) )
             ! selects the approximate (presumably) closer to the root
@@ -219,7 +219,7 @@ module nlsolvers
             character(len=*), parameter :: errmsg = &
                 & "method needs more iterations for convergence"
 
-            if (n < conf % max_iter) then
+            if (n /= conf % max_iter) then
                 if (conf % verbose) then
                     print *, name // " Method: "
                     print *, "solution found in ", n, " iterations"

--- a/nonlinear-equation-solvers/matlab/bisect.m
+++ b/nonlinear-equation-solvers/matlab/bisect.m
@@ -45,7 +45,7 @@ function x = bisect(a, b, f, opt)
     check_bounds
     check_bracket
 
-    n = 0;
+    n = 1;
     x = 0.5 * (a + b);
     while ( n ~= MAX_ITER && abs( f(x) ) > TOL )
 
@@ -107,7 +107,7 @@ function x = bisect(a, b, f, opt)
 
     function report
         % Synopsis: Reports to the user if the method has been successful.
-        if ( n < MAX_ITER )
+        if ( n ~= MAX_ITER )
 	    if (VERBOSE)
                 fprintf('%s Method:\n', name)
                 fprintf('>> Solution found in %d iterations\n', n)

--- a/nonlinear-equation-solvers/matlab/regfal.m
+++ b/nonlinear-equation-solvers/matlab/regfal.m
@@ -35,7 +35,7 @@ function x = regfal(a, b, f, opt)
     check_bounds
     check_bracket
 
-    n = 0;
+    n = 1;
     x = ( a * f(b) - b * f(a) ) / ( f(b) - f(a) );
     while ( n ~= MAX_ITER && abs( f(x) ) > TOL )
 
@@ -96,7 +96,7 @@ function x = regfal(a, b, f, opt)
 
     function report
         % Synopsis: Reports to the user if the method has been successful.
-        if ( n < MAX_ITER )
+        if ( n ~= MAX_ITER )
 	    if (VERBOSE)
                 fprintf('%s Method:\n', name)
                 fprintf('>> Solution found in %d iterations\n', n)

--- a/nonlinear-equation-solvers/matlab/shifter.m
+++ b/nonlinear-equation-solvers/matlab/shifter.m
@@ -34,7 +34,7 @@ function x = shifter(a, b, f, opt)
     check_bounds
     check_bracket
 
-    n = 0;
+    n = 1;
     shift
     while ( n ~= MAX_ITER && abs( f(x) ) > TOL )
 
@@ -107,7 +107,7 @@ function x = shifter(a, b, f, opt)
 
     function report
         % Synopsis: Reports to the user if the method has been successful.
-        if ( n < MAX_ITER )
+        if ( n ~= MAX_ITER )
 	    if (VERBOSE)
                 fprintf('%s Method:\n', name)
                 fprintf('>> Solution found in %d iterations\n', n)

--- a/nonlinear-equation-solvers/python/nlsolvers.py
+++ b/nonlinear-equation-solvers/python/nlsolvers.py
@@ -45,7 +45,7 @@ def bisect(bounds, f, **kwargs):
     a, b = check_bounds(bounds)
 
 
-    n, x = (0, (a + b) / 2)
+    n, x = (1, (a + b) / 2)
     while ( n != max_iter and abs( f(x) ) > tol ):
 
         # updates bracketing interval [a, b]
@@ -73,7 +73,7 @@ def regfal(bounds, f, **kwargs):
     lb, ub = check_bounds(bounds)
 
 
-    n, x = ( 0, ( lb * f(ub) - ub * f(lb) ) / ( f(ub) - f(lb) ) )
+    n, x = ( 1, ( lb * f(ub) - ub * f(lb) ) / ( f(ub) - f(lb) ) )
     while ( n != max_iter and abs( f(x) ) > tol ):
 
         if f(lb) * f(x) < 0:
@@ -102,7 +102,7 @@ def shifter(bounds, f, **kwargs):
     lb, ub = check_bounds(bounds)
 
 
-    n, x = ( 0, shift(lb, ub, f) )
+    n, x = ( 1, shift(lb, ub, f) )
     while ( n != max_iter and abs( f(x) ) > tol ):
 
         if f(lb) * f(x) < 0:
@@ -166,7 +166,7 @@ def optset(**kwargs):
 
 def report(max_iter, it, name, verbose):
     """ Synopsis: Reports if the method has been successful. """
-    if (it < max_iter):
+    if (it != max_iter):
         if verbose:
             print(name + " Method:")
             print(f"solution found in {it} iterations")


### PR DESCRIPTION
COMMENTS:
In most implementations the first iteration is carried out before
the while-loop, so the counter should not start at zero as it was
done.

The report needs only to check if the iteration count is not equal
to the maximum number of iterations. Note that if the method fails
to obtain the solution the iteration counter is guaranteed to be
equal to the maximum number of iterations. Also note that in most
implementations the logical AND is short-circuited so that if the
counter is equal to the maximum number of iterations the while
loop will stop without bothering to check if f(x) satisfies the
convergence criterion.

Runtime checks were done to verify that the report is generated
accordingly.