### PR TITLE
implements a vector class for solving finite-difference problems [clang]

### DIFF
--- a/finite-differences/clang/Makefile
+++ b/finite-differences/clang/Makefile
@@ -1,0 +1,31 @@
+#!/usr/bin/make
+#
+# source: Makefile
+# author: misael-diaz
+# date:   2021/07/20
+#
+# Synopsis:
+# Defines the Makefile for building the program with GNU make.
+#
+# Copyright (c) 2021 Misael Diaz-Maldonado
+#
+# This file is released under the GNU General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+
+include make-inc
+
+all: $(TESTS)
+
+$(TEST_VECTOR_EXE): $(OBJECTS)
+	$(CC) $(CCOPT) $(OBJECTS) -o $(TEST_VECTOR_EXE) $(LIBS)
+
+$(VECTOR_OBJ): $(VECTOR_SRC)
+	$(CC) $(CCOPT) -c $(VECTOR_SRC) -o $(VECTOR_OBJ)
+
+$(TEST_VECTOR_OBJ): $(VECTOR_SRC) $(TEST_VECTOR_SRC)
+	$(CC) $(CCOPT) -c $(TEST_VECTOR_SRC) -o $(TEST_VECTOR_OBJ)
+
+clean:
+	/bin/rm -rf *.o $(TESTS)

--- a/finite-differences/clang/Vector.c
+++ b/finite-differences/clang/Vector.c
@@ -183,6 +183,31 @@ static vector_t* create (size_t size)
 }
 
 
+static vector_t* zeros (size_t size)
+// constructor --- creates a vector of zeros of requested size
+{
+	// allocates memory for the vector
+	vector_t *vec = util_alloc_vector_t ();
+
+	// allocates memory for the data buffer
+	vec -> array = util_alloc_array_double_t (size);
+
+	double *array = vec -> array;
+	// initializes the elements of the vector's data buffer with zeros
+	array = util_init_array_double_t (size, array);
+
+	// defines the vector limits
+	vec -> begin = vec -> array;
+	vec -> avail = ( (vec -> begin) + size * sizeof(double) );
+	vec -> limit = ( (vec -> begin) + size * sizeof(double) );
+	// binds the methods
+	vec -> size  = size_method;
+	vec -> clear = clear_method;
+	vec -> push_back = push_back_method;
+
+	return vec;
+}
+
 static vector_t* linspace (double x_l, double x_u, size_t size)
 // constructor --- creates a vector x = [x_l, x_u] of requested size
 {
@@ -236,4 +261,4 @@ static vector_t* destroy (vector_t* vec)
 
 
 // creates namespace for the vector class constructor and destructor
-vector_namespace const vector = {create, linspace, destroy};
+vector_namespace const vector = {create, zeros, linspace, destroy};

--- a/finite-differences/clang/Vector.c
+++ b/finite-differences/clang/Vector.c
@@ -173,6 +173,23 @@ static void copy_method (void *destination, void *source)
 }
 
 
+static double qnorm_method (void *vector)
+// quick norm method --- does not compute the squared root
+{
+	// gets the vector size
+	size_t size = size_method (vector);
+	// asserts that the type of the (universal) pointer is a vector
+	vector_t *vec = vector;
+
+	double norm = 0;
+	double *data = (vec -> array);
+	for (size_t i = 0; i != size; ++i)
+		norm += (data[i] * data[i]);
+
+	return norm;
+}
+
+
 static vector_t* create (size_t size)
 // constructor --- allocates memory for a vector of requested size
 {
@@ -195,6 +212,7 @@ static vector_t* create (size_t size)
 	vec -> clear = clear_method;
 	vec -> push_back = push_back_method;
 	vec -> copy = copy_method;
+	vec -> qnorm = qnorm_method;
 
 	return vec;
 }
@@ -222,6 +240,7 @@ static vector_t* zeros (size_t size)
 	vec -> clear = clear_method;
 	vec -> push_back = push_back_method;
 	vec -> copy = copy_method;
+	vec -> qnorm = qnorm_method;
 
 	return vec;
 }
@@ -250,6 +269,7 @@ static vector_t* ones (size_t size)
 	vec -> clear = clear_method;
 	vec -> push_back = push_back_method;
 	vec -> copy = copy_method;
+	vec -> qnorm = qnorm_method;
 
 	return vec;
 }
@@ -278,6 +298,7 @@ static vector_t* linspace (double x_l, double x_u, size_t size)
 	vec -> clear = clear_method;
 	vec -> push_back = push_back_method;
 	vec -> copy = copy_method;
+	vec -> qnorm = qnorm_method;
 
 	return vec;
 }

--- a/finite-differences/clang/Vector.c
+++ b/finite-differences/clang/Vector.c
@@ -208,6 +208,33 @@ static vector_t* zeros (size_t size)
 	return vec;
 }
 
+
+static vector_t* ones (size_t size)
+// constructor --- creates a vector of ones of requested size
+{
+	// allocates memory for the vector
+	vector_t *vec = util_alloc_vector_t ();
+
+	// allocates memory for the data buffer
+	vec -> array = util_alloc_array_double_t (size);
+
+	double *array = vec -> array;
+	// initializes the elements of the vector's data buffer with ones
+	for (size_t i = 0; i != size; ++i)
+		array[i] = 1.0;
+
+	// defines the vector limits
+	vec -> begin = vec -> array;
+	vec -> avail = ( (vec -> begin) + size * sizeof(double) );
+	vec -> limit = ( (vec -> begin) + size * sizeof(double) );
+	// binds the methods
+	vec -> size  = size_method;
+	vec -> clear = clear_method;
+	vec -> push_back = push_back_method;
+
+	return vec;
+}
+
 static vector_t* linspace (double x_l, double x_u, size_t size)
 // constructor --- creates a vector x = [x_l, x_u] of requested size
 {
@@ -261,4 +288,4 @@ static vector_t* destroy (vector_t* vec)
 
 
 // creates namespace for the vector class constructor and destructor
-vector_namespace const vector = {create, zeros, linspace, destroy};
+vector_namespace const vector = {create, zeros, ones, linspace, destroy};

--- a/finite-differences/clang/Vector.c
+++ b/finite-differences/clang/Vector.c
@@ -157,6 +157,22 @@ static void push_back_method (void* vector, double data)
 }
 
 
+static void copy_method (void *destination, void *source)
+// performs a shallow copy of the vectors
+{
+	// gets the vector size
+	size_t size = size_method (source);
+	// asserts the vector type
+	vector_t *vsrc = source;
+	vector_t *vdst = destination;
+	// references the data buffers of the vectors
+	double *src = (vsrc -> array);
+	double *dst = (vdst -> array);
+	// delegates the task to the copy utility
+	util_copy_array_double_t (size, src, dst);
+}
+
+
 static vector_t* create (size_t size)
 // constructor --- allocates memory for a vector of requested size
 {
@@ -178,6 +194,7 @@ static vector_t* create (size_t size)
 	vec -> size  = size_method;
 	vec -> clear = clear_method;
 	vec -> push_back = push_back_method;
+	vec -> copy = copy_method;
 
 	return vec;
 }
@@ -204,6 +221,7 @@ static vector_t* zeros (size_t size)
 	vec -> size  = size_method;
 	vec -> clear = clear_method;
 	vec -> push_back = push_back_method;
+	vec -> copy = copy_method;
 
 	return vec;
 }
@@ -231,6 +249,7 @@ static vector_t* ones (size_t size)
 	vec -> size  = size_method;
 	vec -> clear = clear_method;
 	vec -> push_back = push_back_method;
+	vec -> copy = copy_method;
 
 	return vec;
 }
@@ -258,6 +277,7 @@ static vector_t* linspace (double x_l, double x_u, size_t size)
 	vec -> size  = size_method;
 	vec -> clear = clear_method;
 	vec -> push_back = push_back_method;
+	vec -> copy = copy_method;
 
 	return vec;
 }

--- a/finite-differences/clang/Vector.c
+++ b/finite-differences/clang/Vector.c
@@ -1,0 +1,211 @@
+/*
+ * Computational Methods                                 September 09, 2022
+ * ICI 70320
+ * Prof. M Diaz-Maldonado
+ *
+ * source: Vector.c
+ *
+ * Synopsis:
+ * Defines methods of the vector class.
+ *
+ *
+ * Copyright (c) 2022 Misael Diaz-Maldonado
+ *
+ * This file is released under the GNU General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ *
+ * References:
+ * [0] A Koenig and B Moo, Accelerated C++ Practical Programming by
+ *     Example.
+ * [1] JJ McConnell, Analysis of Algorithms, 2nd edition
+ *
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <string.h>
+#include <errno.h>
+#include "vector.h"
+#include "Vector.h"
+
+// implementations:
+static size_t size_method (void* vector)
+// returns the vector size --- the number of elements stored
+{
+	// asserts that the type of the (universal) pointer is a vector
+	vector_t *vec = vector;
+	return ( ( (vec -> avail) - (vec -> begin) ) / sizeof(double) );
+}
+
+
+static void clear_method (void* vector)
+// clears the vector elements
+{
+	// asserts that the type of the (universal) pointer is a vector
+	vector_t *vec = vector;
+	vec -> avail = (vec -> begin);
+}
+
+
+static vector_t* util_alloc_vector_t ()
+// allocates memory for a vector object
+{
+	vector_t *vec = (vector_t*) malloc ( sizeof(vector_t) );
+        if (vec == NULL)
+        {
+		char errmsg [] = "memory allocation error: %s\n";
+		fprintf (stderr, errmsg, strerror(errno) );
+		exit(EXIT_FAILURE);
+        }
+
+	return vec;
+}
+
+
+static double* util_alloc_array_double_t (size_t size)
+// allocates memory for an array of doubles of requested size
+{
+	double *data = (double*) malloc ( size * sizeof(double) );
+	if (data == NULL)
+	{
+		char errmsg [] = "memory allocation error: %s\n";
+		fprintf (stderr, errmsg, strerror(errno) );
+		exit(EXIT_FAILURE);
+        }
+
+	return data;
+}
+
+
+static double* util_init_array_double_t (size_t size, double array[size])
+// initializes array with zeros
+{
+	for (int i = 0; i != size; ++i)
+		array[i] = 0.0;
+
+	return array;
+}
+
+
+static double* util_copy_array_double_t (
+	size_t size, double src[size], double dst[size]
+)
+// copies from the source `src' to the destination `dst' array
+{
+	for (int i = 0; i != size; ++i)
+		dst[i] = src[i];
+
+	return dst;
+}
+
+
+static void grow (vector_t* vec)
+// doubles the vector size
+{
+	size_t numel = size_method (vec);
+	size_t limit = (2 * numel);
+	// creates an array temporary to backup the vector's data buffer
+	double *data = util_alloc_array_double_t (numel);
+
+	// copies data into the backup array temporary
+	data = util_copy_array_double_t (numel, vec -> array, data);
+
+	// destroys the vector's data buffer
+	free (vec -> array);
+	vec -> array = NULL;
+	vec -> begin = NULL;
+	vec -> avail = NULL;
+	vec -> limit = NULL;
+
+	// doubles the memory allocation for the vector's data buffer
+	vec -> array = util_alloc_array_double_t (limit);
+
+	// initializes the vector's data buffer
+	double *array = (vec -> array);
+	array = util_copy_array_double_t (numel, data, array);
+
+	// updates the vector limits
+	vec -> begin = (vec -> array);
+	vec -> avail = ( (vec -> begin) + numel * sizeof(double) );
+	vec -> limit = ( (vec -> begin) + limit * sizeof(double) );
+
+	// frees the array temporary
+	free (data);
+	data = NULL;
+}
+
+
+static void push_back_method (void* vector, double data)
+// pushes elements unto the back of vector, grows the vector as needed
+{
+	// asserts that the type of the (universal) pointer is a vector
+	vector_t *vec = vector;
+	// doubles the vector size if the limit has been reached
+	if ( (vec -> avail) == (vec -> limit) )
+		grow (vec);
+
+	// gets the available location for storing new data
+	size_t avail   = size_method (vec);
+	// copies the input into the data buffer
+	double *array = (vec -> array);
+	array[avail] = data;
+	// updates the vector size
+	vec -> avail += sizeof(double);
+}
+
+
+static vector_t* create (size_t size)
+// constructor --- allocates memory for a vector of requested size
+{
+	// allocates memory for the vector
+	vector_t *vec = util_alloc_vector_t ();
+
+	// allocates memory for the data buffer
+	vec -> array = util_alloc_array_double_t (size);
+
+	double *array = vec -> array;
+	// initializes the elements of the vector's data buffer
+	array = util_init_array_double_t (size, array);
+
+	// defines the vector limits
+	vec -> begin = vec -> array;
+	vec -> avail = vec -> array;
+	vec -> limit = ( (vec -> begin) + size * sizeof(double) );
+	// binds the methods
+	vec -> size  = size_method;
+	vec -> clear = clear_method;
+	vec -> push_back = push_back_method;
+
+	return vec;
+}
+
+
+static vector_t* destroy (vector_t* vec)
+// destructor --- frees the memory allocated for the vector
+{
+	if (vec -> array)
+	{
+		free (vec -> array);
+		vec -> array = NULL;
+	}
+
+	if (vec -> begin)
+		vec -> begin = NULL;
+
+	if (vec -> avail)
+		vec -> avail = NULL;
+
+	if (vec -> limit)
+		vec -> limit = NULL;
+
+	free (vec);
+	vec = NULL;
+	return vec;
+}
+
+
+// creates namespace for the vector class constructor and destructor
+vector_namespace const vector = {create, destroy};

--- a/finite-differences/clang/Vector.c
+++ b/finite-differences/clang/Vector.c
@@ -183,6 +183,34 @@ static vector_t* create (size_t size)
 }
 
 
+static vector_t* linspace (double x_l, double x_u, size_t size)
+// constructor --- creates a vector x = [x_l, x_u] of requested size
+{
+	// allocates memory for the vector
+	vector_t *vec = util_alloc_vector_t ();
+
+	// allocates memory for the data buffer
+	vec -> array = util_alloc_array_double_t (size);
+
+	double *array = vec -> array;				// alias
+	double dx = (x_u - x_l) / ( (double) (size - 1) );	// step
+	// initializes the elements of the vector's data buffer
+	for (size_t i = 0; i != size; ++i)
+		array[i] = x_l + ( (double) i ) * dx;
+
+	// defines the vector limits
+	vec -> begin = vec -> array;
+	vec -> avail = ( (vec -> begin) + size * sizeof(double) );
+	vec -> limit = ( (vec -> begin) + size * sizeof(double) );
+	// binds the methods
+	vec -> size  = size_method;
+	vec -> clear = clear_method;
+	vec -> push_back = push_back_method;
+
+	return vec;
+}
+
+
 static vector_t* destroy (vector_t* vec)
 // destructor --- frees the memory allocated for the vector
 {
@@ -208,4 +236,4 @@ static vector_t* destroy (vector_t* vec)
 
 
 // creates namespace for the vector class constructor and destructor
-vector_namespace const vector = {create, destroy};
+vector_namespace const vector = {create, linspace, destroy};

--- a/finite-differences/clang/Vector.h
+++ b/finite-differences/clang/Vector.h
@@ -28,8 +28,11 @@
 #include "vector.h"
 
 typedef struct {
-vector_t* (*const create) (size_t);	// constructor
-vector_t* (*const destroy) (vector_t*);	// destructor
+// constructors:
+vector_t* (*const create) (size_t);
+vector_t* (*const linspace) (double, double, size_t);
+// destructor:
+vector_t* (*const destroy) (vector_t*);
 } vector_namespace;
 
 #endif

--- a/finite-differences/clang/Vector.h
+++ b/finite-differences/clang/Vector.h
@@ -31,6 +31,7 @@ typedef struct {
 // constructors:
 vector_t* (*const create) (size_t);
 vector_t* (*const zeros) (size_t);
+vector_t* (*const ones) (size_t);
 vector_t* (*const linspace) (double, double, size_t);
 // destructor:
 vector_t* (*const destroy) (vector_t*);

--- a/finite-differences/clang/Vector.h
+++ b/finite-differences/clang/Vector.h
@@ -5,7 +5,7 @@
  * ICI 70320
  * Prof. M Diaz-Maldonado
  *
- * source: vector.h
+ * source: Vector.h
  *
  * Synopsis:
  * Header file for the vector class.

--- a/finite-differences/clang/Vector.h
+++ b/finite-differences/clang/Vector.h
@@ -1,0 +1,35 @@
+#ifndef GUARD_VECTOR_CLASS_H
+#define GUARD_VECTOR_CLASS_H
+/*
+ * Computational Methods                                 September 09, 2022
+ * ICI 70320
+ * Prof. M Diaz-Maldonado
+ *
+ * source: vector.h
+ *
+ * Synopsis:
+ * Header file for the vector class.
+ *
+ *
+ * Copyright (c) 2022 Misael Diaz-Maldonado
+ *
+ * This file is released under the GNU General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ *
+ * References:
+ * [0] A Koenig and B Moo, Accelerated C++ Practical Programming by
+ *     Example.
+ * [1] JJ McConnell, Analysis of Algorithms, 2nd edition
+ *
+ */
+
+#include "vector.h"
+
+typedef struct {
+vector_t* (*const create) (size_t);	// constructor
+vector_t* (*const destroy) (vector_t*);	// destructor
+} vector_namespace;
+
+#endif

--- a/finite-differences/clang/Vector.h
+++ b/finite-differences/clang/Vector.h
@@ -30,6 +30,7 @@
 typedef struct {
 // constructors:
 vector_t* (*const create) (size_t);
+vector_t* (*const zeros) (size_t);
 vector_t* (*const linspace) (double, double, size_t);
 // destructor:
 vector_t* (*const destroy) (vector_t*);

--- a/finite-differences/clang/make-inc
+++ b/finite-differences/clang/make-inc
@@ -1,0 +1,39 @@
+#
+# source: make-inc
+# author: misael-diaz
+# date:   2021/07/20
+#
+# Synopsis:
+# Defines the include file for building the program with GNU make.
+#
+# Copyright (c) 2021 Misael Diaz-Maldonado
+#
+# This file is released under the GNU General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+
+# clang compiler
+CC = gcc-10
+
+# options
+CCOPT = -g -Wall -O0
+
+# libraries
+LIBS = -lm
+
+
+# sources
+VECTOR_SRC = Vector.c
+TEST_VECTOR_SRC     = test.c
+
+
+# objects
+VECTOR_OBJ          = vector.o
+TEST_VECTOR_OBJ     = test.o
+OBJECTS = $(VECTOR_OBJ) $(TEST_VECTOR_OBJ)
+
+
+# executables
+TEST_VECTOR_EXE = test-vector
+TESTS           = $(TEST_VECTOR_EXE)

--- a/finite-differences/clang/test.c
+++ b/finite-differences/clang/test.c
@@ -34,6 +34,7 @@ extern vector_namespace const vector;	// imports vector namespace
 // prototypes:
 void test_pushback();
 void test_zeros();
+void test_ones();
 void test_linspace();
 
 int main() {
@@ -41,6 +42,7 @@ int main() {
 	test_pushback();
 	test_linspace();
 	test_zeros();
+	test_ones();
 	return 0;
 }
 
@@ -84,12 +86,33 @@ void test_pushback() {
 	vec = vector.destroy (vec);
 }
 
+
 void test_zeros ()
 // tests the zeros method
 {
 	size_t size = 16;
 	// creates vector of zeros
 	vector_t *vec = vector.zeros(size);
+
+	// prints the vector size on the console
+	printf("size: %lu \n", vec -> size(vec));
+
+	double *array = (vec -> array);
+	// prints the vector data on the console
+	for (size_t i = 0; i != size; ++i)
+		printf("%7.4f\n", array[i]);
+
+	// frees the memory allocated for the vector
+	vec = vector.destroy (vec);
+}
+
+
+void test_ones ()
+// tests the ones method
+{
+	size_t size = 16;
+	// creates vector of zeros
+	vector_t *vec = vector.ones(size);
 
 	// prints the vector size on the console
 	printf("size: %lu \n", vec -> size(vec));

--- a/finite-differences/clang/test.c
+++ b/finite-differences/clang/test.c
@@ -36,6 +36,7 @@ void test_pushback();
 void test_zeros();
 void test_ones();
 void test_linspace();
+void test_copy();
 
 int main() {
 
@@ -43,6 +44,7 @@ int main() {
 	test_linspace();
 	test_zeros();
 	test_ones();
+	test_copy();
 	return 0;
 }
 
@@ -143,4 +145,44 @@ void test_linspace ()
 
 	// frees the memory allocated for the vector
 	vec = vector.destroy (vec);
+}
+
+
+void test_copy ()
+// tests the (shallow) copy method of the vector class
+{
+	// creates a vector
+	size_t size = 17;
+	double x_l = -1, x_u = 1;
+	vector_t *vec_x = vector.linspace(x_l, x_u, size);
+	// creates another vector of the same size
+	vector_t *vec_y = vector.zeros(size);
+	// copies the contents of vector `x' into vector `y'
+	vec_y -> copy (vec_y, vec_x);
+
+	/* tests the copy method */
+
+	double diff = 0;
+	double *x = (vec_x -> array);
+	double *y = (vec_y -> array);
+	// computes the differences
+	for (size_t i = 0; i != size; ++i)
+		diff += (x[i] - y[i]);
+
+	printf("copy-method-test[0](): ");
+	if (diff != 0.0)
+		printf("FAIL\n");	// fails if there are differences
+	else
+		printf("pass\n");	// passes if the are none
+
+	// checks if the data buffers of the vectors are different objects
+	printf("copy-method-test[1](): ");
+	if (x == y)
+		printf("FAIL\n");	// fails if objects are equal
+	else
+		printf("pass\n");	// passes if different
+
+	// frees the memory allocated for the vectors
+	vec_x = vector.destroy (vec_x);
+	vec_y = vector.destroy (vec_y);
 }

--- a/finite-differences/clang/test.c
+++ b/finite-differences/clang/test.c
@@ -37,6 +37,7 @@ void test_zeros();
 void test_ones();
 void test_linspace();
 void test_copy();
+void test_qnorm();
 
 int main() {
 
@@ -45,6 +46,7 @@ int main() {
 	test_zeros();
 	test_ones();
 	test_copy();
+	test_qnorm();
 	return 0;
 }
 
@@ -261,4 +263,30 @@ void test_copy ()
 	// frees the memory allocated for the vectors
 	vec_x = vector.destroy (vec_x);
 	vec_y = vector.destroy (vec_y);
+}
+
+
+void test_qnorm()
+// tests the quick-norm method
+{
+	// creates a vector that stores the integers in the range [0, 256)
+	size_t size = 256;
+	double x_l = 0, x_u = 255;
+	vector_t *vec = vector.linspace(x_l, x_u, size);
+
+
+	// computes the norm
+	double norm = vec -> qnorm (vec);
+	// computes the expected result -- the sum of squares in [0, 256)
+	double sum_squares = (size * (size - 1) * (2 * size - 1) / 6);
+
+	printf("quick-norm-method-test[0]: ");
+	if (norm != sum_squares)
+		printf("FAIL\n");
+	else
+		printf("pass\n");
+
+
+	// frees the memory allocated for the vector
+	vec = vector.destroy (vec);
 }

--- a/finite-differences/clang/test.c
+++ b/finite-differences/clang/test.c
@@ -157,13 +157,31 @@ void test_ones ()
 	// creates vector of zeros
 	vector_t *vec = vector.ones(size);
 
-	// prints the vector size on the console
-	printf("size: %lu \n", vec -> size(vec));
 
+	double diff = 0;
 	double *array = (vec -> array);
-	// prints the vector data on the console
+	// computes differences
 	for (size_t i = 0; i != size; ++i)
-		printf("%7.4f\n", array[i]);
+		diff += (1.0 - array[i]);
+
+	printf("ones-test[0]: ");
+	if (diff != 0.0)
+		printf("FAIL\n");	// fails if there are differences
+	else
+		printf("pass\n");	// passes if the are none
+
+
+	double sum = 0;
+	// checks the vector size
+	for (size_t i = 0; i != size; ++i)
+		sum += array[i];
+
+	printf("ones-test[1]: ");
+	if (sum != size)
+		printf("FAIL\n");	// fails if size differs
+	else
+		printf("pass\n");	// passes otherwise
+
 
 	// frees the memory allocated for the vector
 	vec = vector.destroy (vec);

--- a/finite-differences/clang/test.c
+++ b/finite-differences/clang/test.c
@@ -198,13 +198,26 @@ void test_linspace ()
 	// creates vector of `size' equally spaced elements in [-1, 1]
 	vector_t *vec = vector.linspace(x_l, x_u, size);
 
-	// prints the vector size on the console
-	printf("size: %lu \n", vec -> size(vec));
 
-	double *array = (vec -> array);
-	// prints the vector data on the console
+	double data [size];
+	double dx = (x_u - x_l) / ( (double) (size - 1) );
+	// stores same data in array temporary
 	for (size_t i = 0; i != size; ++i)
-		printf("%+7.4f\n", array[i]);
+		data[i] = x_l + ( (double) i ) * dx;
+
+
+	double diff = 0;
+	double *array = (vec -> array);
+	// computes differences between the stored and expected data
+	for (size_t i = 0; i != 32; ++i)
+		diff += (data[i] - array[i]);
+
+	printf("linspace-test[0]: ");
+	if (diff != 0.0)
+		printf("FAIL\n");	// fails if there are differences
+	else
+		printf("pass\n");	// passes if the are none
+
 
 	// frees the memory allocated for the vector
 	vec = vector.destroy (vec);

--- a/finite-differences/clang/test.c
+++ b/finite-differences/clang/test.c
@@ -1,0 +1,81 @@
+/*
+ * Computational Methods                                 September 09, 2022
+ * ICI 70320
+ * Prof. M Diaz-Maldonado
+ *
+ * source: test.c
+ *
+ * Synopsis:
+ * Tests the vector class.
+ *
+ *
+ * Copyright (c) 2022 Misael Diaz-Maldonado
+ *
+ * This file is released under the GNU General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ *
+ * References:
+ * [0] A Koenig and B Moo, Accelerated C++ Practical Programming by
+ *     Example.
+ * [1] JJ McConnell, Analysis of Algorithms, 2nd edition
+ * [2] A Gilat and V Subramaniam, Numerical Methods for Engineers and
+ *     Scientists: An Introduction with Applications using MATLAB
+ * [3] H Wendland, Numerical Linear Algebra
+ *
+ */
+
+#include <stdio.h>
+#include "Vector.h"
+
+extern vector_namespace const vector;	// imports vector namespace
+
+// prototypes:
+void test_pushback();
+
+int main() {
+
+	test_pushback();
+	return 0;
+}
+
+// tests:
+void test_pushback() {
+
+	size_t numel = 16;
+	// creates a vector with requested storage capacity
+	vector_t *vec = vector.create (numel);
+
+	// pushes data unto the back of the vector
+	for (int i = 0; i != 32; ++i)
+		vec -> push_back (vec, i);
+
+	double *array = (vec -> array);
+	// prints the data on the console
+	for (size_t i = 0; i != 32; ++i)
+		printf("%f\n", array[i]);
+
+	// prints the vector size on the console
+	printf("size: %lu \n", vec -> size(vec));
+
+	// clears the data stored in vector
+	vec -> clear(vec);
+	printf("cleared vector\n");
+	printf("size: %lu \n", vec -> size(vec));
+
+	// pushes new data unto the back of the vector
+	for (int i = 0; i != 32; ++i)
+		vec -> push_back (vec, 32 - i);
+
+	array = (vec -> array);
+	// prints the new data on the console
+	for (size_t i = 0; i != 32; ++i)
+		printf("%f\n", array[i]);
+
+	// prints the vector size on the console
+	printf("size: %lu \n", vec -> size(vec));
+
+	// frees the memory allocated for the vector
+	vec = vector.destroy (vec);
+}

--- a/finite-differences/clang/test.c
+++ b/finite-differences/clang/test.c
@@ -191,15 +191,19 @@ void test_ones ()
 void test_linspace ()
 // tests the linspace method
 {
-	// creates vector of 33 equally spaced elements in [-1, 1]
-	vector_t *vec = vector.linspace(-1, 1, 33);
+	// defines the vector size
+	size_t size = 33;
+	// defines the vector limits
+	double x_l = -1, x_u = 1;
+	// creates vector of `size' equally spaced elements in [-1, 1]
+	vector_t *vec = vector.linspace(x_l, x_u, size);
 
 	// prints the vector size on the console
 	printf("size: %lu \n", vec -> size(vec));
 
 	double *array = (vec -> array);
 	// prints the vector data on the console
-	for (size_t i = 0; i != 33; ++i)
+	for (size_t i = 0; i != size; ++i)
 		printf("%+7.4f\n", array[i]);
 
 	// frees the memory allocated for the vector

--- a/finite-differences/clang/test.c
+++ b/finite-differences/clang/test.c
@@ -33,12 +33,14 @@ extern vector_namespace const vector;	// imports vector namespace
 
 // prototypes:
 void test_pushback();
+void test_zeros();
 void test_linspace();
 
 int main() {
 
 	test_pushback();
 	test_linspace();
+	test_zeros();
 	return 0;
 }
 
@@ -77,6 +79,25 @@ void test_pushback() {
 
 	// prints the vector size on the console
 	printf("size: %lu \n", vec -> size(vec));
+
+	// frees the memory allocated for the vector
+	vec = vector.destroy (vec);
+}
+
+void test_zeros ()
+// tests the zeros method
+{
+	size_t size = 16;
+	// creates vector of zeros
+	vector_t *vec = vector.zeros(size);
+
+	// prints the vector size on the console
+	printf("size: %lu \n", vec -> size(vec));
+
+	double *array = (vec -> array);
+	// prints the vector data on the console
+	for (size_t i = 0; i != size; ++i)
+		printf("%7.4f\n", array[i]);
 
 	// frees the memory allocated for the vector
 	vec = vector.destroy (vec);

--- a/finite-differences/clang/test.c
+++ b/finite-differences/clang/test.c
@@ -59,30 +59,61 @@ void test_pushback() {
 	for (int i = 0; i != 32; ++i)
 		vec -> push_back (vec, i);
 
-	double *array = (vec -> array);
-	// prints the data on the console
-	for (size_t i = 0; i != 32; ++i)
-		printf("%f\n", array[i]);
+	// stores same data in array temporary
+	double data [32];
+	for (int i = 0; i != 32; ++i)
+		data[i] = i;
 
-	// prints the vector size on the console
-	printf("size: %lu \n", vec -> size(vec));
+	double diff = 0;
+	double *array = (vec -> array);
+	// computes differences
+	for (size_t i = 0; i != 32; ++i)
+		diff += (data[i] - array[i]);
+
+	printf("push-back-method-test[0]: ");
+	if (diff != 0.0)
+		printf("FAIL\n");	// fails if there are differences
+	else
+		printf("pass\n");	// passes if the are none
+
+
+	printf("push-back-method-test[1]: ");
+	if (vec -> size(vec) != 32)
+		printf("FAIL\n");	// fails if size does not match
+	else
+		printf("pass\n");	// passes otherwise
+
 
 	// clears the data stored in vector
 	vec -> clear(vec);
-	printf("cleared vector\n");
-	printf("size: %lu \n", vec -> size(vec));
+	printf("push-back-method-test[2]: ");
+	if (vec -> size(vec) != 0)
+		printf("FAIL\n");	// fails if size does not match
+	else
+		printf("pass\n");	// passes otherwise
+
 
 	// pushes new data unto the back of the vector
 	for (int i = 0; i != 32; ++i)
 		vec -> push_back (vec, 32 - i);
 
-	array = (vec -> array);
-	// prints the new data on the console
-	for (size_t i = 0; i != 32; ++i)
-		printf("%f\n", array[i]);
+	// stores same data in array temporary
+	for (int i = 0; i != 32; ++i)
+		data[i] = (32 - i);
 
-	// prints the vector size on the console
-	printf("size: %lu \n", vec -> size(vec));
+
+	diff = 0.0;
+	array = (vec -> array);
+	// computes differences
+	for (size_t i = 0; i != 32; ++i)
+		diff += (data[i] - array[i]);
+
+	printf("push-back-method-test[3]: ");
+	if (diff != 0.0)
+		printf("FAIL\n");	// fails if there are differences
+	else
+		printf("pass\n");	// passes if the are none
+
 
 	// frees the memory allocated for the vector
 	vec = vector.destroy (vec);

--- a/finite-differences/clang/test.c
+++ b/finite-differences/clang/test.c
@@ -127,13 +127,23 @@ void test_zeros ()
 	// creates vector of zeros
 	vector_t *vec = vector.zeros(size);
 
-	// prints the vector size on the console
-	printf("size: %lu \n", vec -> size(vec));
-
+	double sum = 0;
 	double *array = (vec -> array);
-	// prints the vector data on the console
+	// accumulates the data stored in the vector
 	for (size_t i = 0; i != size; ++i)
-		printf("%7.4f\n", array[i]);
+		sum += array[i];
+
+	printf("zeros-test[0]: ");	// checks stored data
+	if (sum != 0.0)
+		printf("FAIL\n");
+	else
+		printf("pass\n");
+
+	printf("zeros-test[1]: ");
+	if (vec -> size(vec) != size)	// checks vector size
+		printf("FAIL\n");
+	else
+		printf("pass\n");
 
 	// frees the memory allocated for the vector
 	vec = vector.destroy (vec);

--- a/finite-differences/clang/test.c
+++ b/finite-differences/clang/test.c
@@ -33,10 +33,12 @@ extern vector_namespace const vector;	// imports vector namespace
 
 // prototypes:
 void test_pushback();
+void test_linspace();
 
 int main() {
 
 	test_pushback();
+	test_linspace();
 	return 0;
 }
 
@@ -75,6 +77,25 @@ void test_pushback() {
 
 	// prints the vector size on the console
 	printf("size: %lu \n", vec -> size(vec));
+
+	// frees the memory allocated for the vector
+	vec = vector.destroy (vec);
+}
+
+
+void test_linspace ()
+// tests the linspace method
+{
+	// creates vector of 33 equally spaced elements in [-1, 1]
+	vector_t *vec = vector.linspace(-1, 1, 33);
+
+	// prints the vector size on the console
+	printf("size: %lu \n", vec -> size(vec));
+
+	double *array = (vec -> array);
+	// prints the vector data on the console
+	for (size_t i = 0; i != 33; ++i)
+		printf("%+7.4f\n", array[i]);
 
 	// frees the memory allocated for the vector
 	vec = vector.destroy (vec);

--- a/finite-differences/clang/vector.h
+++ b/finite-differences/clang/vector.h
@@ -36,5 +36,6 @@ double* array;
 size_t (*size) (void*);
 void (*clear) (void*);
 void (*push_back) (void*, double);
+void (*copy) (void*, void*);
 } vector_t;
 #endif

--- a/finite-differences/clang/vector.h
+++ b/finite-differences/clang/vector.h
@@ -1,0 +1,40 @@
+#ifndef GUARD_VECTOR_H
+#define GUARD_VECTOR_H
+/*
+ * Computational Methods                             	 September 09, 2022
+ * ICI 70320
+ * Prof. M Diaz-Maldonado
+ *
+ * source: vector.h
+ *
+ * Synopsis:
+ * Header file for the vector class.
+ *
+ *
+ * Copyright (c) 2022 Misael Diaz-Maldonado
+ *
+ * This file is released under the GNU General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ *
+ * References:
+ * [0] A Koenig and B Moo, Accelerated C++ Practical Programming by
+ *     Example.
+ * [1] JJ McConnell, Analysis of Algorithms, 2nd edition
+ *
+ */
+
+
+typedef struct {
+// data
+double* begin;
+double* avail;
+double* limit;
+double* array;
+// methods
+size_t (*size) (void*);
+void (*clear) (void*);
+void (*push_back) (void*, double);
+} vector_t;
+#endif

--- a/finite-differences/clang/vector.h
+++ b/finite-differences/clang/vector.h
@@ -37,5 +37,6 @@ size_t (*size) (void*);
 void (*clear) (void*);
 void (*push_back) (void*, double);
 void (*copy) (void*, void*);
+double (*qnorm) (void*);		// quick norm
 } vector_t;
 #endif

--- a/finite-differences/python/steady-1d-transport.py
+++ b/finite-differences/python/steady-1d-transport.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Computational Methods                                    September 09, 2022
+ICI 70320
+Prof. M Diaz-Maldondo
+
+Synopsis:
+Solves the one-dimensional transport problem with a uniform source term by
+finite differences. The non-dimensional field variable (temperature) is
+subjected to the following boundary conditions: g(x_l) = g(x_u) = 0, where
+`x_l' and `x_u' are the lower and upper limits, respectively, on the x-axis
+which delimit the system domain.
+
+The field variable is obtained by solving the system of discretized
+equations iteratively via the Jacobi method and the Gauss-Seidel method.
+The code reports the numeric error and plots the field variable.
+
+Copyright (c) 2022 Misael Diaz-Maldonado
+This file is released under the GNU General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+References:
+[0] A Gilat and V Subramaniam, Numerical Methods for Engineers and
+    Scientists: An Introduction with Applications using MATLAB
+[1] H Wendland, Numerical Linear Algebra
+[2] R Johansson, Numerical Python: Scientific Computing and Data
+    Science Applications with NumPy, SciPy, and Matplotlib, 2nd edition
+"""
+
+from numpy import ones
+from numpy import zeros
+from numpy import linspace
+from numpy.linalg import norm
+from matplotlib import pyplot as plt
+
+
+""" default solver parameters """
+
+
+# defines default tolerance and maximum number of iterations
+tol_default = 1.0e-6
+max_iter_default = int('0x0008FFFF', base=16)   # about 500K iters
+
+
+""" defines tailored iterative linear solvers """
+
+
+def Jacobi(N, H, x_lims, opts = (max_iter_default, tol_default) ):
+    """
+    Synopsis:
+    Possible implementation of the Jacobi method for solving the
+    one-dimensional heat transfer problem with a constant (heat) source
+    in the domain x = [x_l, x_u]. The (temperature) field variable is
+    subject to the following boundary conditions: g(x_l) = g(x_u) = 0.
+
+    Inputs:
+    N       (scalar) number of discretization intervals
+    H       (scalar) non-dimensional (heat) source term
+    x_lims  (tuple) storing the x-axis lower and upper limits (x_l, x_u)
+    opts    (tuple) optional, solver parameters (iterations, tolerance)
+
+    Output:
+    g       (1st-rank numpy array) the (temperature) field variable
+
+    Note:
+    The implementation has been tailored to solve this particular problem.
+    """
+
+    # unpacks the maximum number of iterations and the tolerance
+    max_iters, tol = opts
+
+    # unpacks the x-axis lower and upper limits
+    x_l, x_u = x_lims
+
+    # computes the step-size
+    dx = (x_u - x_l) / N
+
+    # defines the right-hand side of the discretized (energy) equations
+    b = -( (dx)**2 * H ) * ones(N + 1)
+
+    # initializes the field (temperature) variable
+    g = zeros(N + 1)
+    """ applies the boundary conditions explicitly for the sake clarity """
+    g[1], g[-1] = (0, 0)    # g(x_l) = g(x_u) = 0
+
+    # defines the initial guess
+    g0 = g.copy()
+
+    """ solves the system of equations iteratively """
+    for j in range(max_iters):
+
+        g[1] = -0.5 * (b[1] - g0[2])
+
+        for i in range(2, N - 1):
+            g[i] = -0.5 * (b[i] - g0[i - 1] - g0[i + 1])
+
+        g[N - 1] = -0.5 * (b[N - 1] - g0[N - 2])
+
+        if ( norm(g - g0) < tol ):
+            print(f"Jacobi(): solution found after {j+1} iterations")
+            break
+
+        g0 = g.copy()
+
+    return g
+
+
+def GaussSeidel(N, H, x_lims, opts = (max_iter_default, tol_default) ):
+    """
+    Synopsis:
+    Possible implementation of the Gauss-Seidel method for solving the
+    one-dimensional heat transfer problem with a constant (heat) source
+    in the domain x = [x_l, x_u]. The (temperature) field variable is
+    subject to the following boundary conditions: g(x_l) = g(x_u) = 0.
+
+    Inputs:
+    N       (scalar) number of discretization intervals
+    H       (scalar) non-dimensional (heat) source term
+    x_lims  (tuple) storing the x-axis lower and upper limits (x_l, x_u)
+    opts    (tuple) optional, solver parameters (iterations, tolerance)
+
+    Output:
+    g       (1st-rank numpy array) the (temperature) field variable
+
+    Note:
+    The implementation has been tailored to solve this particular problem.
+    """
+
+    # unpacks the maximum number of iterations and the tolerance
+    max_iters, tol = opts
+
+    # unpacks the x-axis lower and upper limits
+    x_l, x_u = x_lims
+
+    # computes the step-size
+    dx = (x_u - x_l) / N
+
+    # defines the right-hand side of the discretized (energy) equations
+    b = -( (dx)**2 * H ) * ones(N + 1)
+
+    # initializes the field (temperature) variable
+    g = zeros(N + 1)
+    """ applies the boundary conditions explicitly for the sake clarity """
+    g[1], g[-1] = (0, 0)    # g(x_l) = g(x_u) = 0
+
+    # defines the initial guess
+    g0 = g.copy()
+
+    """ solves the system of equations iteratively """
+    for j in range(max_iters):
+
+        g[1] = -0.5 * (b[1] - g0[2])
+
+        for i in range(2, N - 1):
+            g[i] = -0.5 * (b[i] - g[i - 1] - g0[i + 1])
+
+        g[N - 1] = -0.5 * (b[N - 1] - g[N - 2])
+
+        if ( norm(g - g0) < tol ):
+            print(f"Gauss-Seidel(): solution found after {j+1} iterations")
+            break
+
+        g0 = g.copy()
+
+    return g
+
+
+""" problem definition """
+
+
+# defines the number of discretization intervals as a power of two
+n = 8
+N = 2**n
+
+# defines the x-axis lower and upper limits (or bounds), x = [x_l, x_u]
+x_lims = (x_l, x_u) = (-1, 1)
+x = linspace(x_l, x_u, N + 1)
+
+# defines the (heat) source term
+H = 1
+
+
+""" numeric solution """
+
+
+# solves the discretized (energy) equations by applying the Jacobi method
+g_Jacobi = Jacobi(N, H, x_lims)
+# applies the Gauss-Seidel method to solve the discretized equations
+g_GaussSeidel = GaussSeidel(N, H, x_lims)
+
+
+""" post-processing """
+# compares the numeric solutions against the analytic one
+
+
+# computes the analytic solution
+analytic = 0.5 * H * (1 - x**2)
+
+# computes the average error
+err_Jacobi      = norm(analytic - g_Jacobi) / analytic.size
+err_GaussSeidel = norm(analytic - g_GaussSeidel) / analytic.size
+errors = (
+    f'Average Error:\n'
+    f'Jacobi:       {err_Jacobi:.4e}\n'
+    f'Gauss-Seidel: {err_GaussSeidel:.4e}\n'
+)
+print(errors)
+
+
+""" visualization """
+
+
+plt.close('all')
+plt.ion()
+fig, ax = plt.subplots()
+ax.plot(x, g_Jacobi,      color='black', label='Jacobi')
+ax.plot(x, g_GaussSeidel, color='black', label='Gauss-Seidel')
+ax.plot(x, analytic,      color='red',   label='analytic')
+ax.legend()


### PR DESCRIPTION
Implements  a vector class for solving finite-difference problem in C language (clang).

The vector supports the following methods: push-back, clear, size, qnorm, and copy. The copy method creates a shallow copy of the vector and the qnorm method computes the norm of a vector without actually evaluating the squared root for speed (quick-norm).

An initial version of the solver in python is also included in this merge.

The objective is to complete the implementation of the solver in C for performance reasons. 