### PR TITLE
handles IO Error [clang]

### DIFF
--- a/finite-differences/clang/test.c
+++ b/finite-differences/clang/test.c
@@ -1417,7 +1417,7 @@ void test_transient_1d_transport_GaussSeidel ()
 	for (size_t i = 0; i != steps; ++i)
 	{
 		// writes g(t, x) to the data file every 256 steps
-		if (i % (0x00000100) == 0)
+		if (pdefile && i % (0x00000100) == 0)
 		{
 			vector_t *vec_g = pdesol[1];
 			double time = ( (double) i ) * dt;
@@ -1495,5 +1495,5 @@ void test_transient_1d_transport_GaussSeidel ()
 	vec_state = vector.destroy (vec_state);
 
 	// closes the data file that stores the transient data
-	fclose(pdefile);
+	if (pdefile) fclose(pdefile);
 }


### PR DESCRIPTION
COMMENTS:
Adds missing code that handles Input-Output IO error.

The code simply omits the data export in the event of an IO error so that it gets the chance to free the allocated memory resources, as it should to avert memory leaks.

NOTE: This should have been part of the previous merge.